### PR TITLE
Fix connection port

### DIFF
--- a/Sources/SwiftyCurl/cURLConnection.swift
+++ b/Sources/SwiftyCurl/cURLConnection.swift
@@ -186,24 +186,20 @@ open class cURLConnection {
         }
         
         var urlString: String = rawString
-        var port: String?
-        
-        if let portRange = cmp.rangeOfPort {
-            let colonRange = Range<String.Index>(uncheckedBounds: (urlString.index(before: portRange.lowerBound),portRange.upperBound))
-            port = urlString.substring(with: portRange)
-            
-            urlString.replaceSubrange(colonRange, with: "")
+
+        if let portValue = cmp.port {
+          urlString = urlString.replacingOccurrences(of: ":\(portValue)", with: "")
         }
-        
-        
+
         self.url = urlString
-        if let prt = port, let portValue = Int(prt) {
-            self.port = portValue
+
+        if let port = cmp.port {
+          self.port = port
         } else {
-            self.port = nil
+          self.port = nil
         }
     }
-    
+
     open func request(_ req: cURLRequest) throws -> cURLResponse {
         
         try setURLFrom(request: req)


### PR DESCRIPTION
@dmcyk I'm not sure about this one, but `swift build` complained about "rangeOfPort is only available on OS X 10.11 or newer". That's why I'm trying to achieve the same results by using `port` property.